### PR TITLE
Added rcl, rcr, rol, ror opcodes

### DIFF
--- a/Asm86.js
+++ b/Asm86.js
@@ -2382,6 +2382,70 @@ Asm86Emulator.prototype.OP = {
 			return Asm86Emulator.prototype._flagSign(ctx, r, op1.size);
 		}
 	},
+	rcl: {
+		operandCount: 2,
+		op1Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_MEM,
+		op2Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_IMM, //imm or CL only!
+		validate: Asm86Emulator.prototype._validateShift,
+		exec: function (ctx, op1, op2) {
+			var a = op1.get(), b = op2.get() & 31, r, c = ctx.flagCarry;
+			if (!b) return a;
+			if (ctx.errorOccurred) return undefined;
+			r = op1.set(a << b | c << (b - 1) | (a >>> ((op1.size << 3) - b + 1)) & ((1 << (b - 1)) - 1));
+			if (ctx.errorOccurred) return undefined;
+			ctx.flagCarry = (a >>> ((op1.size << 3) - b)) & 1;
+			if (b === 1) ctx.flagOv = ctx.flagCarry ^ (a >>> (op1.size << 3) - 2);
+			return r;
+		}
+	},
+	rcr: {
+		operandCount: 2,
+		op1Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_MEM,
+		op2Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_IMM, //imm or CL only!
+		validate: Asm86Emulator.prototype._validateShift,
+		exec: function (ctx, op1, op2) {
+			var a = op1.get(), b = op2.get() & 31, r, c = ctx.flagCarry;
+			if (!b) return a;
+			if (ctx.errorOccurred) return undefined;
+			r = op1.set(((a & ((1 << (b - 1)) - 1)) << ((op1.size << 3) - b + 1)) | (c << ((op1.size << 3) - b)) | (a >>> b));
+			if (ctx.errorOccurred) return undefined;
+			ctx.flagCarry = (a >>> (b - 1)) & 1;
+			if (b === 1) ctx.flagOv = c ^ (a >>> (op1.size << 3) - 1);
+			return r;
+		}
+	},
+	rol: {
+		operandCount: 2,
+		op1Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_MEM,
+		op2Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_IMM, //imm or CL only!
+		validate: Asm86Emulator.prototype._validateShift,
+		exec: function (ctx, op1, op2) {
+			var a = op1.get(), b = op2.get() & 31, r;
+			if (!b) return a;
+			if (ctx.errorOccurred) return undefined;
+			r = op1.set((a << b) | ((a >>> ((op1.size << 3) - b)) & ((1 << b) - 1)));
+			if (ctx.errorOccurred) return undefined;
+			ctx.flagCarry = (a >>> ((op1.size << 3) - b)) & 1;
+			if (b === 1) ctx.flagOv = ctx.flagCarry ^ (a >>> (op1.size << 3) - 2);
+			return r;
+		}
+	},
+	ror: {
+		operandCount: 2,
+		op1Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_MEM,
+		op2Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_IMM, //imm or CL only!
+		validate: Asm86Emulator.prototype._validateShift,
+		exec: function (ctx, op1, op2) {
+			var a = op1.get(), b = op2.get() & 31, r, c = ctx.flagCarry;
+			if (!b) return a;
+			if (ctx.errorOccurred) return undefined;
+			r = op1.set(((a & ((1 << b) - 1)) << ((op1.size << 3) - b)) | (a >>> b));
+			if (ctx.errorOccurred) return undefined;
+			ctx.flagCarry = (a >>> (b - 1)) & 1;
+			if (b === 1) ctx.flagOv = c ^ (a >>> (op1.size << 3) - 1);
+			return r;
+		}
+	},
 	shl: {
 		operandCount: 2,
 		op1Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_MEM,

--- a/Asm86.js
+++ b/Asm86.js
@@ -2394,7 +2394,7 @@ Asm86Emulator.prototype.OP = {
 			r = op1.set(a << b | c << (b - 1) | (a >>> ((op1.size << 3) - b + 1)) & ((1 << (b - 1)) - 1));
 			if (ctx.errorOccurred) return undefined;
 			ctx.flagCarry = (a >>> ((op1.size << 3) - b)) & 1;
-			if (b === 1) ctx.flagOv = ctx.flagCarry ^ (a >>> (op1.size << 3) - 2);
+			if (b === 1) ctx.flagOv = ctx.flagCarry ^ ((a >>> (op1.size << 3) - 2) & 1);
 			return r;
 		}
 	},
@@ -2410,7 +2410,7 @@ Asm86Emulator.prototype.OP = {
 			r = op1.set(((a & ((1 << (b - 1)) - 1)) << ((op1.size << 3) - b + 1)) | (c << ((op1.size << 3) - b)) | (a >>> b));
 			if (ctx.errorOccurred) return undefined;
 			ctx.flagCarry = (a >>> (b - 1)) & 1;
-			if (b === 1) ctx.flagOv = c ^ (a >>> (op1.size << 3) - 1);
+			if (b === 1) ctx.flagOv = c ^ ((a >>> (op1.size << 3) - 1) & 1);
 			return r;
 		}
 	},
@@ -2426,7 +2426,7 @@ Asm86Emulator.prototype.OP = {
 			r = op1.set((a << b) | ((a >>> ((op1.size << 3) - b)) & ((1 << b) - 1)));
 			if (ctx.errorOccurred) return undefined;
 			ctx.flagCarry = (a >>> ((op1.size << 3) - b)) & 1;
-			if (b === 1) ctx.flagOv = ctx.flagCarry ^ (a >>> (op1.size << 3) - 2);
+			if (b === 1) ctx.flagOv = ctx.flagCarry ^ ((a >>> (op1.size << 3) - 2) & 1);
 			return r;
 		}
 	},
@@ -2436,13 +2436,13 @@ Asm86Emulator.prototype.OP = {
 		op2Type: Asm86Emulator.prototype.TYPE_REG | Asm86Emulator.prototype.TYPE_IMM, //imm or CL only!
 		validate: Asm86Emulator.prototype._validateShift,
 		exec: function (ctx, op1, op2) {
-			var a = op1.get(), b = op2.get() & 31, r, c = ctx.flagCarry;
+			var a = op1.get(), b = op2.get() & 31, r;
 			if (!b) return a;
 			if (ctx.errorOccurred) return undefined;
 			r = op1.set(((a & ((1 << b) - 1)) << ((op1.size << 3) - b)) | (a >>> b));
 			if (ctx.errorOccurred) return undefined;
 			ctx.flagCarry = (a >>> (b - 1)) & 1;
-			if (b === 1) ctx.flagOv = c ^ (a >>> (op1.size << 3) - 1);
+			if (b === 1) ctx.flagOv = ctx.flagCarry ^ ((a >>> (op1.size << 3) - 1) & 1);
 			return r;
 		}
 	},


### PR DESCRIPTION
I've added a few opcodes to the emulator.
I've also attached an updated CodeMirror/Asm86.js file that adds the opcodes to the keywords, since this isn't part of the repository.

[CodeMirror-Asm86.zip](https://github.com/carlosrafaelgn/Asm86/files/1982459/CodeMirror-Asm86.zip)
