### PR TITLE
Fixed bug in IMUL instruction for 16-bit operand

### DIFF
--- a/Asm86.js
+++ b/Asm86.js
@@ -3278,7 +3278,7 @@ Asm86Emulator.prototype.OP = {
 					tmp.setInt16(0, ctx.regs.ax.get());
 					b = a * tmp.getInt16(0);
 					ctx.regs.ax.set(b & 0xFFFF);
-					b = ctx.regs.ax.set(b >>> 16);
+					b = ctx.regs.dx.set(b >>> 16);
 					if (b && b !== 0xFFFF)
 						ctx.flagCarry = 1;
 					break;


### PR DESCRIPTION
I found a bug in the IMUL instruction for 16-bit operands.
The ax register was being overridden with the value that should have been stored in dx.